### PR TITLE
eventLoop.cpp 안쓰는 변수 삭제 및  변수명 변경

### DIFF
--- a/incs/EventLoop.hpp
+++ b/incs/EventLoop.hpp
@@ -16,17 +16,11 @@ class EventLoop {
     int _kqFd;
     std::vector<struct kevent> _ChangeList;
 
-    std::map<int, Request *> _cli;
-    std::map<int, std::string> _request;
-    std::map<int, Response *> _response2;
+    std::map<int, Request *> _request;
+    std::map<int, Response *> _response;
     std::map<int, int> _offset;
-    std::map<std::string, std::string> _html;
-    // std::map<int, std::vector<char> > _cgiResponse;
-    // std::map<int, std::vector<int> > _cgi;
-    std::string _phpheader;
     std::vector<ServerBlock> _server;
     EventLoop();
-    void OpenHtmlFile(std::string filePath);
 
   public:
     EventLoop(Config &con);


### PR DESCRIPTION
변경
_cli -> _request
_response2 -> _response

삭제
_request 삭제
_html 삭제
_cgiResponse 삭제
_cgi 삭제
_phpheader 삭제
void OpenHtmlFile(std::string filePath) 함수 삭제